### PR TITLE
Get Favorites

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'factory_bot_rails'
 gem 'faker'
 gem 'faraday'
+gem 'fast_jsonapi'
 gem 'figaro'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 3.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,8 @@ GEM
       i18n (~> 1.6.0)
     faraday (0.16.2)
       multipart-post (>= 1.2, < 3)
+    fast_jsonapi (1.5)
+      activesupport (>= 4.2)
     ffi (1.11.1)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -188,6 +190,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   faraday
+  fast_jsonapi
   figaro
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::FavoritesController < ApplicationController
+  def show
+    favorite = UserSong.find(params[:id])
+    render json: SongSerializer.new(Song.find(favorite.song_id))
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::API
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
+  private
+
+  def record_not_found
+    render json: { error: 'Not found' }, status: 404
+  end
 end

--- a/app/serializers/song_serializer.rb
+++ b/app/serializers/song_serializer.rb
@@ -1,0 +1,9 @@
+class SongSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attributes :name,
+             :album,
+             :artist,
+             :genre,
+             :rating
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      get '/favorites/:id', to: 'favorites#show'
+    end
+  end
 end

--- a/db/migrate/20191007215354_add_genre_to_songs.rb
+++ b/db/migrate/20191007215354_add_genre_to_songs.rb
@@ -1,0 +1,5 @@
+class AddGenreToSongs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :songs, :genre, :string
+  end
+end

--- a/db/migrate/20191007215541_add_rating_to_songs.rb
+++ b/db/migrate/20191007215541_add_rating_to_songs.rb
@@ -1,0 +1,5 @@
+class AddRatingToSongs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :songs, :rating, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_05_184543) do
+ActiveRecord::Schema.define(version: 2019_10_07_215541) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,8 @@ ActiveRecord::Schema.define(version: 2019_10_05_184543) do
     t.string "artist"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "genre"
+    t.integer "rating"
   end
 
   create_table "user_songs", force: :cascade do |t|

--- a/spec/factories/songs.rb
+++ b/spec/factories/songs.rb
@@ -1,8 +1,10 @@
 FactoryBot.define do
   factory :song do
-    source_track_id { 1 }
-    name { "MyString" }
-    album { "MyString" }
-    artist { "MyString" }
+    source_track_id { |n| n }
+    name { Faker::Music::Phish.song }
+    album { Faker::Music.album }
+    artist { Faker::Music.band }
+    genre { Faker::Music.genre }
+    rating { rand(101) }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    email { Faker::Internet.email }
+  end
+end

--- a/spec/requests/api/v1/favorites_api_endpoint_spec.rb
+++ b/spec/requests/api/v1/favorites_api_endpoint_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'Favorites API endpoint' do
+  before :each do
+    @user = create(:user)
+
+    @s1 = create(:song)
+    @s2 = create(:song)
+    @s3 = create(:song)
+    @s4 = create(:song)
+
+    @f1 = create(:user_song, user: @user, song: @s1)
+    @f2 = create(:user_song, user: @user, song: @s2)
+    @f3 = create(:user_song, user: @user, song: @s3)
+  end
+
+  it 'user can retrieve a single favorite by ID' do
+    get "/api/v1/favorites/#{@f1.id}"
+
+    favorite = JSON.parse(response.body, symbolize_names: true)[:data][:attributes]
+
+    expect(response).to be_successful
+
+    expect(favorite[:name]).to eq(@s1.name)
+    expect(favorite[:album]).to eq(@s1.album)
+    expect(favorite[:artist]).to eq(@s1.artist)
+    expect(favorite[:genre]).to eq(@s1.genre)
+    expect(favorite[:rating]).to eq(@s1.rating)
+  end
+end

--- a/spec/requests/api/v1/favorites_api_endpoint_spec.rb
+++ b/spec/requests/api/v1/favorites_api_endpoint_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Favorites API endpoint' do
+RSpec.describe 'Favorites API endpoint', type: :request do
   before :each do
     @user = create(:user)
 
@@ -26,5 +26,15 @@ RSpec.describe 'Favorites API endpoint' do
     expect(favorite[:artist]).to eq(@s1.artist)
     expect(favorite[:genre]).to eq(@s1.genre)
     expect(favorite[:rating]).to eq(@s1.rating)
+  end
+
+  it 'user receives a 404 error when no favorite is found' do
+    get '/api/v1/favorites/9999'
+
+    error = JSON.parse(response.body, symbolize_names: true)[:error]
+
+    expect(response.status).to eq(404)
+
+    expect(error).to eq('Not found')
   end
 end


### PR DESCRIPTION
This PR adds the ability for a user to retrieve a favorite by ID.  Genre and rating attributes have been added to the Song model, and fast_jsonapi gem has been added to development dependancies.

- Adds favorites request spec with tests for retrieving a favorite by ID, and receiving a 404 error when no favorite matching the ID is found

- Updates the User and Song factories with Faker data

- Adds Api::V1::FavoritesController, with #show and route

- Adds SongSerializer utilizing fast_json

- Adds ApplicationController#record_not_found to assist in handling 404 errors