### PR TITLE
Post Favorites

### DIFF
--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -1,6 +1,24 @@
 class Api::V1::FavoritesController < ApplicationController
+  before_action :set_favorite, only: :show
+
+  def create
+    song = Song.find_or_create_by(song_params)
+    UserSong.create(song: song, user_id: params[:user_id])
+
+    render json: SongSerializer.new(song), status: 201
+  end
+
   def show
-    favorite = UserSong.find(params[:id])
-    render json: SongSerializer.new(Song.find(favorite.song_id))
+    render json: SongSerializer.new(Song.find(@favorite.song_id))
+  end
+
+  private
+
+  def song_params
+    params.permit(:source_track_id, :name, :artist, :album, :genre, :rating)
+  end
+
+  def set_favorite
+    @favorite = UserSong.find(params[:id])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  alias_attribute :favorites, :user_songs
+
   has_many :user_songs
   has_many :songs, through: :user_songs
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      get '/favorites/:id', to: 'favorites#show'
+      resources :favorites, only: [:show, :create]
     end
   end
 end

--- a/spec/factories/songs.rb
+++ b/spec/factories/songs.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :song do
-    source_track_id { |n| n }
+    source_track_id { rand(99999999) }
     name { Faker::Music::Phish.song }
     album { Faker::Music.album }
     artist { Faker::Music.band }

--- a/spec/requests/api/v1/favorites_api_endpoint_spec.rb
+++ b/spec/requests/api/v1/favorites_api_endpoint_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe 'Favorites API endpoint', type: :request do
 
     @f1 = create(:user_song, user: @user, song: @s1)
     @f2 = create(:user_song, user: @user, song: @s2)
-    @f3 = create(:user_song, user: @user, song: @s3)
   end
 
   it 'user can retrieve a single favorite by ID' do
@@ -19,7 +18,7 @@ RSpec.describe 'Favorites API endpoint', type: :request do
 
     favorite = JSON.parse(response.body, symbolize_names: true)[:data][:attributes]
 
-    expect(response).to be_successful
+    expect(response.status).to eq(200)
 
     expect(favorite[:name]).to eq(@s1.name)
     expect(favorite[:album]).to eq(@s1.album)
@@ -36,5 +35,27 @@ RSpec.describe 'Favorites API endpoint', type: :request do
     expect(response.status).to eq(404)
 
     expect(error).to eq('Not found')
+  end
+
+  it 'user can create a new favorite' do
+    params = {  source_track_id: @s3.source_track_id,
+                name: @s3.name,
+                artist: @s3.artist,
+                album: @s3.album,
+                rating: @s3.rating,
+                user_id: @user.id
+              }
+
+    post '/api/v1/favorites', params: params
+
+    favorite = JSON.parse(response.body, symbolize_names: true)[:data][:attributes]
+
+    expect(response.status).to eq(201)
+
+    expect(favorite[:name]).to eq(@s3.name)
+    expect(favorite[:album]).to eq(@s3.album)
+    expect(favorite[:artist]).to eq(@s3.artist)
+    expect(favorite[:genre]).to eq(@s3.genre)
+    expect(favorite[:rating]).to eq(@s3.rating)
   end
 end


### PR DESCRIPTION
This PR adds the functionality for a user to add a new favorite.  When a user submits the song to be favorited, it is either found or created.  A UserSong is then created using the song's ID and the user's ID.  The user ID is passed in the params for the time being, since we're rolling with a single user—in the future this will probably be replaced with a `current_user` method in ApplicationController that checks against the API key being passed in the request.

- Adds spec for creating a new favorite
- Adds User#favorites as an alias to User#user_songs
- Adds FavoritesController#set_favorite, #song_params and #create action with route