### PR TITLE
Delete Favorites

### DIFF
--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::FavoritesController < ApplicationController
-  before_action :set_favorite, only: :show
+  before_action :find_favorite, only: [:show, :destroy]
 
   def create
     song = Song.find_or_create_by(song_params)
@@ -12,13 +12,17 @@ class Api::V1::FavoritesController < ApplicationController
     render json: SongSerializer.new(Song.find(@favorite.song_id))
   end
 
+  def destroy
+    @favorite.destroy
+  end
+
   private
 
   def song_params
     params.permit(:source_track_id, :name, :artist, :album, :genre, :rating)
   end
 
-  def set_favorite
+  def find_favorite
     @favorite = UserSong.find(params[:id])
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      resources :favorites, only: [:show, :create]
+      resources :favorites, only: [:show, :create, :destroy]
     end
   end
 end

--- a/spec/requests/api/v1/favorites_api_endpoint_spec.rb
+++ b/spec/requests/api/v1/favorites_api_endpoint_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe 'Favorites API endpoint', type: :request do
     expect(favorite[:rating]).to eq(@s1.rating)
   end
 
-  it 'user receives a 404 error when no favorite is found' do
-    get '/api/v1/favorites/9999'
+  it 'user receives a 404 error when no favorite is found to GET' do
+    get '/api/v1/favorites/not_found'
 
     error = JSON.parse(response.body, symbolize_names: true)[:error]
 
@@ -57,5 +57,25 @@ RSpec.describe 'Favorites API endpoint', type: :request do
     expect(favorite[:artist]).to eq(@s3.artist)
     expect(favorite[:genre]).to eq(@s3.genre)
     expect(favorite[:rating]).to eq(@s3.rating)
+
+    expect(@user.favorites.count).to eq(3)
+  end
+
+  it 'user can delete an existing favorite' do
+    delete "/api/v1/favorites/#{@f2.id}"
+
+    expect(response.status).to eq(204)
+
+    expect(@user.favorites.count).to eq(1)
+  end
+
+  it 'user receives a 404 error when no favorite is found to DELETE' do
+    delete "/api/v1/favorites/not_found"
+
+    error = JSON.parse(response.body, symbolize_names: true)[:error]
+
+    expect(response.status).to eq(404)
+
+    expect(error).to eq('Not found')
   end
 end


### PR DESCRIPTION
This PR adds functionality for a user to delete a favorite.  Returns a 204 no content, or 404 if no favorite is found to delete.

- Adds spec for user deleting a favorite, and sad path spec for favorite not found
- Adds FavoritesController#destroy with route, renames #set_favorite to #find_favorite