### PR TITLE
Put Favorites

### DIFF
--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -1,9 +1,10 @@
 class Api::V1::FavoritesController < ApplicationController
   before_action :authenticate_user!
-  before_action :find_favorite, only: [:show, :destroy]
+  before_action :find_favorite, only: [:show, :update, :destroy]
 
   def index
     songs = current_user.songs
+
     render json: SongSerializer.new(songs)
   end
 
@@ -16,6 +17,12 @@ class Api::V1::FavoritesController < ApplicationController
 
   def show
     render json: SongSerializer.new(Song.find(@favorite.song_id))
+  end
+
+  def update
+    @favorite.song.update(song_params)
+
+    render json: SongSerializer.new(@favorite.song), status: 200
   end
 
   def destroy

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :favorites, only: [:index, :show, :create, :destroy]
+      resources :favorites, except: [:new, :edit]
     end
   end
 end

--- a/spec/requests/api/v1/favorites_api_endpoint_spec.rb
+++ b/spec/requests/api/v1/favorites_api_endpoint_spec.rb
@@ -66,7 +66,8 @@ RSpec.describe 'Favorites API endpoint', type: :request do
     end
 
     it 'user can create a new favorite' do
-      params = {  source_track_id: @s3.source_track_id,
+      params = {
+                  source_track_id: @s3.source_track_id,
                   name: @s3.name,
                   artist: @s3.artist,
                   album: @s3.album,
@@ -87,6 +88,40 @@ RSpec.describe 'Favorites API endpoint', type: :request do
       expect(favorite[:rating]).to eq(@s3.rating)
 
       expect(@user.favorites.count).to eq(3)
+    end
+
+    it 'user can update an existing favorite' do
+      params = {
+                  source_track_id: @s1.source_track_id,
+                  name: @s1.name,
+                  artist: @s1.artist,
+                  album: @s1.album,
+                  genre: @s1.genre,
+                  rating: @s1.rating
+                }
+
+      put "/api/v1/favorites/#{@f2.id}", params: params
+
+      favorite = JSON.parse(response.body, symbolize_names: true)[:data][:attributes]
+
+      expect(response.status).to eq(200)
+
+      expect(favorite[:name]).to eq(@s1.name)
+      expect(favorite[:album]).to eq(@s1.album)
+      expect(favorite[:artist]).to eq(@s1.artist)
+      expect(favorite[:genre]).to eq(@s1.genre)
+      expect(favorite[:rating]).to eq(@s1.rating)
+    end
+
+    it 'user receives a 404 error when no favorite is found to update' do
+      put '/api/v1/favorites/not_found'
+
+      expect(response.status).to eq(404)
+
+      error = JSON.parse(response.body, symbolize_names: true)[:errors][0]
+
+      expect(error[:status]).to eq(404)
+      expect(error[:title]).to eq('Not Found')
     end
 
     it 'user can delete an existing favorite' do


### PR DESCRIPTION
This PR adds the ability for a User to update an existing favorite.

- Adds specs for User updating favorite, as well as sad path for no favorite found
- Adds `PUT /api/v1/favorites` route
- Adds FavoritesController#update action